### PR TITLE
Fix for SSR boilerplates issue 'window is not defined'

### DIFF
--- a/slickCarousel.vue
+++ b/slickCarousel.vue
@@ -6,7 +6,11 @@
 <script>
 import Vue from 'vue';
 import $ from 'jquery';
-import 'slick-carousel';
+
+// check if request comes from browser and is not server rendered
+if (process.BROWSER_BUILD) {
+	var slick = require('slick-carousel')
+}
 
 export default {
 


### PR DESCRIPTION
Using a boilerplate for Vue (as Nuxt.js) with this component shows the 'window is not defined' error, because the slick module is server-rendered instead of client/browser rendered. Checking "process.BROWSER_BUILD" addresses the rendering to the client, and slick works.
Since it is not possibile to use "import" in an if statement, I've changed it to "require".