### PR TITLE
Added support for nuxt v1.0.0

### DIFF
--- a/slickCarousel.vue
+++ b/slickCarousel.vue
@@ -9,7 +9,7 @@ import $ from 'jquery';
 
 // Check if request comes from browser and is not server rendered
 // BROWSER_BUILD is for Nuxt.js compatibility
-if (process.BROWSER_BUILD || process.BROWSER_BUILD == null) {
+if (process.BROWSER_BUILD || process.BROWSER_BUILD == null || process.browser || process.browser == null) {
   const slick = require('slick-carousel')
 }
 


### PR DESCRIPTION
Nuxt v1.0.0-rc3 removed process.BROWSER_BUILD in favour of process.browser.
see: https://github.com/nuxt/nuxt.js/releases/tag/1.0.0-rc3