### PR TITLE
off all events in the destroy method

### DIFF
--- a/slickCarousel.vue
+++ b/slickCarousel.vue
@@ -52,6 +52,19 @@ export default {
     },
 
     destroy() {
+      const $slick = $(this.$el);
+
+      $slick.off('afterChange', this.onAfterChange);
+      $slick.off('beforeChange', this.onBeforeChange);
+      $slick.off('breakpoint', this.onBreakpoint);
+      $slick.off('destroy', this.onDestroy);
+      $slick.off('edge', this.onEdge);
+      $slick.off('init', this.onInit);
+      $slick.off('reInit', this.onReInit);
+      $slick.off('setPosition', this.onSetPosition);
+      $slick.off('swipe', this.onSwipe);
+      $slick.off('lazyLoaded', this.onLazyLoaded);
+      $slick.off('lazyLoadError', this.onLazyLoadError);
       $(this.$el).slick('unslick');
     },
 


### PR DESCRIPTION
We need to **off** al events because if you call reSlick multiple times you'll have multiple **on** events emit.