### PR TITLE
improve SSR detection under nuxtjs

### DIFF
--- a/slickCarousel.vue
+++ b/slickCarousel.vue
@@ -8,7 +8,8 @@ import Vue from 'vue';
 import $ from 'jquery';
 
 // Check if the request came from the browser and is not server rendered
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined' &&
+  ((typeof process !== undefined && process.browser) || typeof process === undefined)) {
   const slick = require('slick-carousel')
 }
 


### PR DESCRIPTION
It seems like a window object actually does exist on SSR in some cases in nuxt for unknown reasons - this would cause SSR to fail sporadically for me. The nuxtjs bundler will set a process global similar to Node in the browser environment which can be detected by checking `process.browser`.

The improved check:

- Does the standard `typeof window` check
- Checks if `process` is defined with a `typeof` check (always `true` under SSR on Node) and only passes if `process.browser` is truthy
- If `process` is completely undefined, it's fairly safe to assume we're running in the browser