### PR TITLE
docs: fix style import in js

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ new Vue({
 
 If you need, you can import slick styles too:
 
-```javascript
-import `node_modules/slick-carousel/slick/slick.css`;
+```js
+// MyCarrousel.vue
+import 'slick-carousel/slick/slick.css';
 ```


### PR DESCRIPTION
Fixed the example since a static import cannot use backticks and it should not reference `node_modules` either.
I think adding an example about importing in a `style` tag (in a vue file) would also help.