### PR TITLE
Improve TypeScript definitions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,2 +1,10 @@
-declare const Slick:any;
+import Vue from "vue";
+
+declare class Slick extends Vue {
+    next(): void;
+    prev(): void;
+    reSlick(): void;
+    goTo(index: number): void;
+}
+
 export default Slick;


### PR DESCRIPTION
Currently the TS definitions is not much useful. Slick definition is now a class not a 'any' const and has the four methods declared. For now the event listeners are not included because I am not able to figure out what type 'event' param is. I guess it is some kind of jQuery event. I tried to figure it out from [jQuery declarations](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/jquery/JQuery.d.ts) but I am not sure.